### PR TITLE
chore: restrict zlib so it can be installed with scikit-garden

### DIFF
--- a/.ci_support/linux_64_numpy1.22python3.10.____cpython.yaml
+++ b/.ci_support/linux_64_numpy1.22python3.10.____cpython.yaml
@@ -32,4 +32,4 @@ zip_keys:
 - - python
   - numpy
 zlib:
-- '1'
+- '1.2'

--- a/.ci_support/linux_64_numpy1.22python3.8.____cpython.yaml
+++ b/.ci_support/linux_64_numpy1.22python3.8.____cpython.yaml
@@ -32,4 +32,4 @@ zip_keys:
 - - python
   - numpy
 zlib:
-- '1'
+- '1.2'

--- a/.ci_support/linux_64_numpy1.22python3.9.____cpython.yaml
+++ b/.ci_support/linux_64_numpy1.22python3.9.____cpython.yaml
@@ -32,4 +32,4 @@ zip_keys:
 - - python
   - numpy
 zlib:
-- '1'
+- '1.2'

--- a/.ci_support/osx_64_numpy1.22python3.10.____cpython.yaml
+++ b/.ci_support/osx_64_numpy1.22python3.10.____cpython.yaml
@@ -32,4 +32,4 @@ zip_keys:
 - - python
   - numpy
 zlib:
-- '1'
+- '1.2'

--- a/.ci_support/osx_64_numpy1.22python3.8.____cpython.yaml
+++ b/.ci_support/osx_64_numpy1.22python3.8.____cpython.yaml
@@ -32,4 +32,4 @@ zip_keys:
 - - python
   - numpy
 zlib:
-- '1'
+- '1.2'

--- a/.ci_support/osx_64_numpy1.22python3.9.____cpython.yaml
+++ b/.ci_support/osx_64_numpy1.22python3.9.____cpython.yaml
@@ -32,4 +32,4 @@ zip_keys:
 - - python
   - numpy
 zlib:
-- '1'
+- '1.2'

--- a/.ci_support/osx_arm64_numpy1.22python3.10.____cpython.yaml
+++ b/.ci_support/osx_arm64_numpy1.22python3.10.____cpython.yaml
@@ -32,4 +32,4 @@ zip_keys:
 - - python
   - numpy
 zlib:
-- '1'
+- '1.2'

--- a/.ci_support/osx_arm64_numpy1.22python3.8.____cpython.yaml
+++ b/.ci_support/osx_arm64_numpy1.22python3.8.____cpython.yaml
@@ -32,4 +32,4 @@ zip_keys:
 - - python
   - numpy
 zlib:
-- '1'
+- '1.2'

--- a/.ci_support/osx_arm64_numpy1.22python3.9.____cpython.yaml
+++ b/.ci_support/osx_arm64_numpy1.22python3.9.____cpython.yaml
@@ -32,4 +32,4 @@ zip_keys:
 - - python
   - numpy
 zlib:
-- '1'
+- '1.2'

--- a/.ci_support/win_64_python3.10.____cpython.yaml
+++ b/.ci_support/win_64_python3.10.____cpython.yaml
@@ -22,4 +22,4 @@ zip_keys:
 - - python
   - numpy
 zlib:
-- '1'
+- '1.2'

--- a/.ci_support/win_64_python3.8.____cpython.yaml
+++ b/.ci_support/win_64_python3.8.____cpython.yaml
@@ -22,4 +22,4 @@ zip_keys:
 - - python
   - numpy
 zlib:
-- '1'
+- '1.2'

--- a/.ci_support/win_64_python3.9.____cpython.yaml
+++ b/.ci_support/win_64_python3.9.____cpython.yaml
@@ -22,4 +22,4 @@ zip_keys:
 - - python
   - numpy
 zlib:
-- '1'
+- '1.2'

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,7 +9,7 @@ source:
   sha256: 4544c5e29df28ee24ac92779273c3c5c954618b44c7e747b259e967aaa6d8c64
 
 build:
-  number: 0
+  number: 1
   script: {{ PYTHON }} -m pip install --no-deps --ignore-installed .
   skip: true  # [py>310 or py<38]
 


### PR DESCRIPTION
scikit-garden 0.1.3 requires libzlib 1.2

pin was removed in https://github.com/conda-forge/genomekit-feedstock/pull/7 which brought in libzlib 1.3

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
